### PR TITLE
Set transition from name prop on created and set name prop default value to fade

### DIFF
--- a/src/components/VuePageTransition.vue
+++ b/src/components/VuePageTransition.vue
@@ -24,6 +24,7 @@ export default {
     }
   },
   created () {
+    this.transition = this.$props.name;
     this.$router.beforeEach((to, from, next) => {
       this.transition = to.meta.transition
         ? to.meta.transition

--- a/src/components/VuePageTransition.vue
+++ b/src/components/VuePageTransition.vue
@@ -16,7 +16,12 @@
 <script>
 export default {
   name: 'vue-page-transition',
-  props: ['name'],
+  props: {
+    name: {
+      type: String,
+      default: 'fade'
+    }
+  },
   data () {
     return {
       transition: 'fade',


### PR DESCRIPTION
Fix #38 
1. [set transition from name prop on created](https://github.com/R-N/vue-page-transition/commit/ee34cd9807941ab4c59cbd057610a85a30c8ef82).
2. [set name prop default value to 'fade'](https://github.com/R-N/vue-page-transition/commit/ae609e56012ddd9d5caf68c90993c62e6a1b9bf2).